### PR TITLE
Use "flip-toolkit" and fix a bunch of bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This library strives to imitate its parent, `react-flip-toolkit`, as closely as 
 | `flipId` **(required)** | –       | `string`   | Use this to tell `vue-flip-toolkit` how elements should be matched across renders so they can be animated.                                                                                                                                                                                                                                                      |
 | `inverseFlipId`         | –       | `string`   | Refer to the id of the parent `Flipped` container whose transform you want to cancel out. If this prop is provided, the `Flipped` component will become a limited version of itself that is only responsible for cancelling out its parent transform. It will read from any provided transform props and will ignore all other props (besides `inverseFlipId`.) |
 | `stagger`               | –       | `string`   | Provide a natural, spring-based staggering effect in which the spring easing of each item is pinned to the previous one's movement. If you want to get more granular, you can provide a string key and the element will be staggered with other elements with the same key.                                                                                     |
+| `delayUntil`            | –       | `string`   | Delay an animation by providing a reference to another Flipped component that it should wait for before animating (the other Flipped component should have a stagger delay as that is the only use case in which this prop is necessary.)                                                                                                                       |
 | `shouldInvert`          | –       | `function` | A function provided with the current and previous `decisionData` props passed down by the Flipper component. Returns a boolean indicating whether to apply inverted transforms to all `Flipped` children that request it via an `inverseFlipId`.                                                                                                                |
 | `shouldFlip`            | –       | `function` | A function provided with the current and previous decisionData props passed down by the `Flipper` component. Returns a `boolean` to indicate whether a `Flipped` component should animate at that particular moment or not.                                                                                                                                     |
 | `opacity`               | false   | `boolean`  |                                                                                                                                                                                                                                                                                                                                                                 |
@@ -117,11 +118,13 @@ You got it.
 [Fantastic Tutorial](https://alex.holachek.com/rft-tutorial/)
 
 ### 5) Scale Animation + Anime.js
+
 [Source](stories/Scale.vue)
 
 <img width="600" src="https://i.imgur.com/BpQvrfG.gif" />
 
 ### 6) Material Design inspired animation
+
 [Source](stories/Material.vue)
 
 <img width="600" src="https://i.imgur.com/b00260y.gif" />

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "build-storybook": "build-storybook -s ./storybook-assets",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {
-    "flip-toolkit": "^7.0.6"
-  },
   "devDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
@@ -36,5 +33,8 @@
     "vue-loader": "^15.7.0",
     "vue-router": "^3.0.3",
     "vue-template-compiler": "^2.6.10"
+  },
+  "dependencies": {
+    "flip-toolkit": "^7.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "vue-template-compiler": "^2.6.10"
   },
   "dependencies": {
-    "flip-toolkit": "^7.0.6"
+    "flip-toolkit": "^7.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "react-flip-toolkit": "^6.5.8"
+    "flip-toolkit": "^7.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",

--- a/src/Flipped.vue
+++ b/src/Flipped.vue
@@ -5,7 +5,7 @@ export default {
   props: {
     flipId: String,
     inverseFlipId: String,
-    stagger: String,
+    stagger: [String, Boolean],
     shouldFlip: Function,
     shouldInvert: Function,
     scale: {

--- a/src/Flipped.vue
+++ b/src/Flipped.vue
@@ -5,6 +5,7 @@ export default {
   props: {
     flipId: String,
     inverseFlipId: String,
+    delayUntil: String,
     stagger: [String, Boolean],
     shouldFlip: Function,
     shouldInvert: Function,
@@ -26,6 +27,7 @@ export default {
       this.addFlippedElement({
         element: this.$el,
         flipId: this.flipId,
+        delayUntil: this.delayUntil,
         shouldFlip: this.shouldFlip,
         shouldInvert: this.shouldInvert,
         onStart: el => this.$emit("on-start", { el, id: this.flipId }),

--- a/src/Flipper.vue
+++ b/src/Flipper.vue
@@ -33,6 +33,7 @@ export default {
     addFlippedElement({
       element,
       flipId,
+      delayUntil,
       stagger,
       shouldFlip,
       shouldInvert,
@@ -45,6 +46,7 @@ export default {
       this.flipInstance.addFlipped({
         element,
         flipId,
+        ...(delayUntil ? { delayUntil } : undefined),
         ...(stagger ? { stagger } : undefined),
         ...(shouldFlip ? { shouldFlip } : undefined),
         ...(shouldInvert ? { shouldInvert } : undefined),

--- a/src/Flipper.vue
+++ b/src/Flipper.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import Flipper from "react-flip-toolkit/es/core";
+import { Flipper } from "flip-toolkit";
 export default {
   name: "flipper",
   provide() {
@@ -82,7 +82,7 @@ export default {
     flipKey(newKey, oldKey) {
       if (newKey !== oldKey) {
         this.$nextTick(() => {
-          this.flipInstance.onUpdate(oldKey, newKey);
+          this.flipInstance.update(oldKey, newKey);
         });
       }
     }

--- a/src/Flipper.vue
+++ b/src/Flipper.vue
@@ -85,6 +85,11 @@ export default {
           this.flipInstance.update(oldKey, newKey);
         });
       }
+    },
+    staggerConfig(oldConfig, newConfig) {
+      if (newConfig !== oldConfig) {
+        this.flipInstance.staggerConfig = newConfig;
+      }
     }
   }
 };

--- a/stories/Accordion.vue
+++ b/stories/Accordion.vue
@@ -1,12 +1,49 @@
 <template>
-  <Flipper :flipKey="focused" spring="gentle" :staggerConfig="staggerConfig">
+  <Flipper :flipKey="focused" :staggerConfig="staggerConfig">
     <div class="m-4">
       <div v-for="(num, index) in list" :key="index">
-        <Flipped :flipId="`card-${index}`" v-if="index !== focused" stagger="card">
-          <div @click="toggleItem(index)" role="button" class="bg-grey h-8 my-4"></div>
+        <Flipped
+          :shouldInvert="shouldFlip(index)"
+          :flipId="`card-${index}`"
+          v-if="index !== focused"
+          stagger="card"
+        >
+          <div
+            @click="toggleItem(index)"
+            role="button"
+            class="bg-grey h-8 my-4 flex items-center p-4"
+          >
+            <Flipped :inverseFlipId="`card-${index}`">
+              <div>
+                <Flipped
+                  :delayUntil="`card-${index}`"
+                  :shouldFlip="shouldFlip(index)"
+                  :flipId="`avatar-card-${index}`"
+                >
+                  <div class="bg-grey-dark rounded-full w-3 h-3"></div>
+                </Flipped>
+              </div>
+            </Flipped>
+          </div>
         </Flipped>
         <Flipped :flipId="`card-${index}`" v-else stagger="card">
-          <div @click="toggleItem(index)" role="button" class="bg-grey h-32 my-4"></div>
+          <div
+            @click="toggleItem(index)"
+            role="button"
+            class="bg-grey h-32 my-4 flex items-center justify-center p-4"
+          >
+            <Flipped :inverseFlipId="`card-${index}`">
+              <div>
+                <Flipped
+                  delayUntil="foo"
+                  :shouldFlip="shouldFlip(index)"
+                  :flipId="`avatar-card-${index}`"
+                >
+                  <div class="bg-grey-dark rounded-full w-12 h-12"></div>
+                </Flipped>
+              </div>
+            </Flipped>
+          </div>
         </Flipped>
       </div>
     </div>
@@ -26,11 +63,10 @@ export default {
   data() {
     return {
       focused: null,
-      list: Array(6)
+      list: Array(8)
         .fill()
         .map(() => ({
-          open: false,
-          description: ["a", "b", "c"]
+          open: false
         }))
     };
   },
@@ -60,7 +96,6 @@ export default {
       return {
         card: {
           reverse: this.focused === null,
-          // reverse: true,
           speed: 0.1
         }
       };

--- a/stories/Accordion.vue
+++ b/stories/Accordion.vue
@@ -3,43 +3,35 @@
     <div class="m-4">
       <div v-for="(num, index) in list" :key="index">
         <Flipped
-          :shouldInvert="shouldFlip(index)"
           :flipId="`card-${index}`"
-          v-if="index !== focused"
           stagger="card"
+          :shouldInvert="shouldFlip(index)"
+          v-if="index !== focused"
         >
-          <div
-            @click="toggleItem(index)"
-            role="button"
-            class="bg-grey h-8 my-4 flex items-center p-4"
-          >
-            <Flipped :inverseFlipId="`card-${index}`">
+          <div @click="toggleItem(index)" role="button" class="bg-grey my-4">
+            <Flipped class="min-h-4 p-4" :inverseFlipId="`card-${index}`">
               <div>
                 <Flipped
                   :delayUntil="`card-${index}`"
                   :shouldFlip="shouldFlip(index)"
                   :flipId="`avatar-card-${index}`"
                 >
-                  <div class="bg-grey-dark rounded-full w-3 h-3"></div>
+                  <div class="inline-block bg-grey-dark rounded-full w-3 h-3"></div>
                 </Flipped>
               </div>
             </Flipped>
           </div>
         </Flipped>
         <Flipped :flipId="`card-${index}`" v-else stagger="card">
-          <div
-            @click="toggleItem(index)"
-            role="button"
-            class="bg-grey h-32 my-4 flex items-center justify-center p-4"
-          >
-            <Flipped :inverseFlipId="`card-${index}`">
+          <div @click="toggleItem(index)" role="button" class="bg-grey my-4 text-center">
+            <Flipped class="h-32 p-4" :inverseFlipId="`card-${index}`">
               <div>
                 <Flipped
-                  delayUntil="foo"
+                  :delayUntil="`card-${index}`"
                   :shouldFlip="shouldFlip(index)"
                   :flipId="`avatar-card-${index}`"
                 >
-                  <div class="bg-grey-dark rounded-full w-12 h-12"></div>
+                  <div class="inline-block bg-grey-dark rounded-full w-12 h-12"></div>
                 </Flipped>
               </div>
             </Flipped>
@@ -65,18 +57,13 @@ export default {
       focused: null,
       list: Array(8)
         .fill()
-        .map(() => ({
-          open: false
+        .map((_, i) => ({
+          open: false,
+          label: `Card ${i + 1}`
         }))
     };
   },
   methods: {
-    handleStart({ el, id }) {
-      setTimeout(() => {
-        el.classList.add("animated-in");
-      }, 600);
-    },
-    handleComplete({ el, id }) {},
     shouldFlip(index) {
       return (prev, current) => {
         return index === prev || index === current;
@@ -96,7 +83,7 @@ export default {
       return {
         card: {
           reverse: this.focused === null,
-          speed: 0.1
+          speed: 1
         }
       };
     },

--- a/stories/Accordion.vue
+++ b/stories/Accordion.vue
@@ -1,75 +1,16 @@
 <template>
-  <div class="staggered-list-content">
-    <Flipper :flipKey="focused" :staggerConfig="staggerConfig" spring="gentle">
-      <ul class="list">
-        <li @click="toggleItem(index)" v-for="(num,index) in list" :key="index">
-          <Flipped
-            v-if="index !== focused"
-            :flipId="`listItem-${index}`"
-            stagger="card"
-            :shouldInvert="shouldFlip(index)"
-          >
-            <div class="listItem">
-              <Flipped :inverseFlipId="`listItem-${index}`">
-                <div class="listItemContent">
-                  <Flipped
-                    :flipId="`avatar-${index}`"
-                    :shouldFlip="shouldFlip(index)"
-                    stagger="card-content"
-                  >
-                    <div class="avatar"></div>
-                  </Flipped>
-                  <div class="description">
-                    <Flipped
-                      v-for="thing in num.description"
-                      :key="thing"
-                      :shouldFlip="shouldFlip(index)"
-                      stagger="card-content"
-                      :flipId="`description-${index}-${thing}`"
-                    >
-                      <div></div>
-                    </Flipped>
-                  </div>
-                </div>
-              </Flipped>
-            </div>
-          </Flipped>
-          <Flipped
-            @on-start="handleStart"
-            @on-complete="handleComplete"
-            v-else
-            :flipId="`listItem-${index}`"
-            stagger="card"
-          >
-            <div class="expandedListItem">
-              <Flipped :inverseFlipId="`listItem-${index}`">
-                <div class="expandedListItemContent">
-                  <Flipped :flipId="`avatar-${index}`" stagger="card-content">
-                    <div class="avatar avatarExpanded"></div>
-                  </Flipped>
-                  <div class="description">
-                    <Flipped
-                      v-for="thing in num.description"
-                      stagger="card-content"
-                      :key="thing"
-                      :flipId="`description-${index}-${thing}`"
-                    >
-                      <div></div>
-                    </Flipped>
-                  </div>
-                  <div class="additional-content">
-                    <div></div>
-                    <div></div>
-                    <div></div>
-                  </div>
-                </div>
-              </Flipped>
-            </div>
-          </Flipped>
-        </li>
-      </ul>
-    </Flipper>
-  </div>
+  <Flipper :flipKey="focused" spring="gentle" :staggerConfig="staggerConfig">
+    <div class="m-4">
+      <div v-for="(num, index) in list" :key="index">
+        <Flipped :flipId="`card-${index}`" v-if="index !== focused" stagger="card">
+          <div @click="toggleItem(index)" role="button" class="bg-grey h-8 my-4"></div>
+        </Flipped>
+        <Flipped :flipId="`card-${index}`" v-else stagger="card">
+          <div @click="toggleItem(index)" role="button" class="bg-grey h-32 my-4"></div>
+        </Flipped>
+      </div>
+    </div>
+  </Flipper>
 </template>
 
 <script>
@@ -85,20 +26,12 @@ export default {
   data() {
     return {
       focused: null,
-      list: [
-        {
+      list: Array(6)
+        .fill()
+        .map(() => ({
           open: false,
           description: ["a", "b", "c"]
-        },
-        {
-          open: false,
-          description: ["a", "b", "c"]
-        },
-        {
-          open: false,
-          description: ["a", "b", "c"]
-        }
-      ]
+        }))
     };
   },
   methods: {
@@ -107,9 +40,7 @@ export default {
         el.classList.add("animated-in");
       }, 600);
     },
-    handleComplete({ el, id }) {
-      console.log("Finished", el, id);
-    },
+    handleComplete({ el, id }) {},
     shouldFlip(index) {
       return (prev, current) => {
         return index === prev || index === current;
@@ -128,8 +59,9 @@ export default {
     staggerConfig() {
       return {
         card: {
-          reverse: this.focused !== null ? true : false,
-          speed: 0.5
+          reverse: this.focused === null,
+          // reverse: true,
+          speed: 0.1
         }
       };
     },
@@ -140,113 +72,3 @@ export default {
 };
 </script>
 
-<style scoped>
-.staggered-list-content {
-  width: 400px;
-  margin: 2rem auto;
-}
-.list {
-  list-style-type: none;
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  padding: 0;
-}
-.list li {
-  width: 100%;
-}
-.list li + li {
-  margin-top: 1rem;
-}
-.listItem {
-  width: 100%;
-  cursor: pointer;
-  background-color: #ffd379;
-  overflow: hidden;
-}
-.listItemContent {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 1rem;
-}
-.avatar {
-  width: 4rem;
-  height: 4rem;
-  border-radius: 100px;
-  background-color: #282c34;
-  margin-right: 2rem;
-}
-.avatarExpanded {
-  width: 8rem;
-  height: 8rem;
-  margin-right: 0;
-  margin-bottom: 1rem;
-}
-.description > div {
-  background-color: #282c34;
-  width: 14rem;
-  border-radius: 6px;
-  height: 0.5rem;
-}
-.description > div:nth-of-type(2) {
-  width: 11rem;
-}
-.description > div:nth-of-type(3) {
-  width: 8rem;
-}
-.description > div + div {
-  margin-top: 1rem;
-}
-.expandedListItem .description {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-}
-.expandedListItem {
-  cursor: pointer;
-  background-color: #ffd379;
-}
-.expandedListItemContent {
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.additional-content {
-  width: 100%;
-  margin-top: 2rem;
-}
-
-.additional-content > div {
-  opacity: 0;
-  border-radius: 3px;
-  background-color: #282c34;
-  height: 5rem;
-}
-
-/* content fade in animations */
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-.animated-in .additional-content > div {
-  animation: fadeIn 0.4s forwards;
-}
-
-.additional-content > div:nth-of-type(2) {
-  animation-delay: 0.15s;
-}
-.additional-content > div:nth-of-type(3) {
-  animation-delay: 0.3s;
-}
-.additional-content > div + div {
-  margin-top: 1rem;
-}
-</style>

--- a/stories/List.vue
+++ b/stories/List.vue
@@ -6,7 +6,7 @@
         @click="shuffle"
       >shuffle</button>
       <ul class="list mt-4">
-        <Flipped v-for="num in list" :key="num" :flipId="num.toString()">
+        <Flipped v-for="num in list" :key="num" :flipId="num.toString()" :stagger="stagger">
           <li>{{num}}</li>
         </Flipped>
       </ul>
@@ -28,6 +28,7 @@ import Flipped from "../src/Flipped";
 
 export default {
   name: "list",
+  props: ["stagger"],
   components: {
     Flipper,
     Flipped

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -61,6 +61,14 @@ storiesOf("Examples", module)
       template: `<List></List>`
     };
   })
+  .add("List Shuffle (Stagger)", () => {
+    return {
+      components: {
+        List
+      },
+      template: `<List :stagger="true"></List>`
+    };
+  })
   .add("Scale", () => {
     return {
       components: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,6 +3794,13 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flip-toolkit@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/flip-toolkit/-/flip-toolkit-7.0.6.tgz#eec6fe8003334879dc7b129d1d9b557e407c8d21"
+  integrity sha512-BtL9dm4a0Oh+Q9a5JBfI+VaasjHjDdkuexV5Q6bAnFqnQU3KQrhgT2QLIAlVGf0xOMzsfGudOutTQgHOS2QyKA==
+  dependencies:
+    react-flip-toolkit "^7.0.6"
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -6212,10 +6219,10 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-flip-toolkit@^6.5.8:
-  version "6.5.9"
-  resolved "https://registry.yarnpkg.com/react-flip-toolkit/-/react-flip-toolkit-6.5.9.tgz#c8ad78a8cf651f98526c15a51d2f4d63e722090e"
-  integrity sha512-0im7XXPBQIS4jiXQTfc5huDEYyNeWtCAZjkytJPMT3P8qroul/ii9SX5ijqHwPUIblttZUYrOSKkdFdPHHHZcw==
+react-flip-toolkit@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/react-flip-toolkit/-/react-flip-toolkit-7.0.6.tgz#eb4b6f17c00f92084a817ce8b4f69dda2a11fdc3"
+  integrity sha512-zZpwNfAGS8/WRrHKOA224NP2aVG4ryVx9vkTkxFsU7tkGUpM5AvjsICYmOVDJhEl5wmR36SjMSmWFicloJVibA==
   dependencies:
     rematrix "0.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,12 +3794,12 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flip-toolkit@^7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/flip-toolkit/-/flip-toolkit-7.0.6.tgz#eec6fe8003334879dc7b129d1d9b557e407c8d21"
-  integrity sha512-BtL9dm4a0Oh+Q9a5JBfI+VaasjHjDdkuexV5Q6bAnFqnQU3KQrhgT2QLIAlVGf0xOMzsfGudOutTQgHOS2QyKA==
+flip-toolkit@^7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/flip-toolkit/-/flip-toolkit-7.0.7.tgz#5cd71c0375ce189294b5ace0d7ec3569a1577b35"
+  integrity sha512-jqAqiJPlD0SqSFdnk0fhM4EMOt/JLCkyWaxv6aaDTGtnDioL3QwXPq0wQ4clxHLp2euOjCbegeGxbgsr3j/kXg==
   dependencies:
-    react-flip-toolkit "^7.0.6"
+    react-flip-toolkit "^7.0.7"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -6219,10 +6219,10 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-flip-toolkit@^7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/react-flip-toolkit/-/react-flip-toolkit-7.0.6.tgz#eb4b6f17c00f92084a817ce8b4f69dda2a11fdc3"
-  integrity sha512-zZpwNfAGS8/WRrHKOA224NP2aVG4ryVx9vkTkxFsU7tkGUpM5AvjsICYmOVDJhEl5wmR36SjMSmWFicloJVibA==
+react-flip-toolkit@^7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/react-flip-toolkit/-/react-flip-toolkit-7.0.7.tgz#a50d455ff4f9f9961042a7a0eb23bd5a2154c963"
+  integrity sha512-1aORVOoaseauhoBg86P1qy4RgG0spzT50s2Ewiju20KtQjcNdkyqObyzOrl7ETd5fCkLV6uzgkJe8AEzuxYJBQ==
   dependencies:
     rematrix "0.2.2"
 


### PR DESCRIPTION
In response to https://github.com/mattrothenberg/vue-flip-toolkit/issues/17, this PR aims to do the following

- [x] Use `flip-toolkit` instead of `react-flip-toolkit` (since the distribution model of these packages has changed recently)
- [x] Permit use of `boolean` values for `stagger` prop on `Flipped` component
- [x] Expose `delayUntil` prop on `Flipped` component
- [x] Make `staggerConfig` reactive and fix stagger issues