### PR TITLE
Fix typo easeInQuad

### DIFF
--- a/stories/Scale.vue
+++ b/stories/Scale.vue
@@ -80,7 +80,7 @@ export default {
       anime({
         targets: squares,
         opacity: [0, 1],
-        delay: anime.stagger(40, { easing: "easeINQuad" })
+        delay: anime.stagger(40, { easing: "easeInQuad" })
       });
     }
   }


### PR DESCRIPTION
Hello,

A fix for a typo in the ease function name that throws an error: 

```
vue.runtime.esm.js?2b0e:1888 TypeError: Cannot read property 'apply' of undefined
    at applyArguments (anime.es.js?1209:53)
    at parseEasings (anime.es.js?1209:276)
    at Function.stagger (anime.es.js?1209:1185)
```