### PR TITLE
Made compatible with vue 3

### DIFF
--- a/src/Flipped.vue
+++ b/src/Flipped.vue
@@ -48,7 +48,7 @@ export default {
     }
   },
   render() {
-    return this.$scopedSlots.default({});
+    return this.$scopedSlots.default()[0];
   }
 };
 </script>


### PR DESCRIPTION
As Vue 3 has kept most of the options API the same, it is only one line of code that needs to be changed. 

But you have to compile the templates with the new version of `vue-template-compiler`, otherwise, the components will not work. 

**Important:** I have **not** updated the dependencies (important for `vue-template-compiler`), because I think you are also using the same dependencies to build the examples in the `stories` folder. Since I didn't want to break those and I am not familiar with how `rollup` works, I kept `package.json` unchanged.